### PR TITLE
Fix run mode of model 

### DIFF
--- a/backend/models/interfaces/model_search.py
+++ b/backend/models/interfaces/model_search.py
@@ -104,7 +104,8 @@ def answer_question(question, answer_text, model, tokenizer):
     # There should be a segment_id for every input token.
     assert len(segment_ids) == len(input_ids)
 
-    outputs = model(torch.tensor([input_ids]),  # The tokens representing our input text.
+    with torch.inference_mode(): ## Run the model in inference mode
+        outputs = model(torch.tensor([input_ids]),  # The tokens representing our input text.
                     # The segment IDs to differentiate question from answer_text
                     token_type_ids=torch.tensor([segment_ids]),
                     return_dict=True)


### PR DESCRIPTION
added code to run the model in inference_mode. 

## Description
There was a bug in the model_search code (used by ElasticBert) where it didn't use the correct torch model mode. #60 

## Type of Change

- [ X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [x] All new and existing tests pass
